### PR TITLE
fixing wrong label extraction  in options.py

### DIFF
--- a/qeschema/options.py
+++ b/qeschema/options.py
@@ -48,7 +48,7 @@ def get_specie_related_values(name, **kwargs):
         tag_specie = value['@specie']
         tag_values = value['$']
         tag_spin = value.get('@spin')
-        if value.get('label') == 'no Hubbard':  # FIXME ?? (maybe '@label' instead?)
+        if value.get('@label') == 'no Hubbard': 
             continue
 
         specie_index = 1

--- a/tests/examples/pw/FeO_LDAU_standard.xml
+++ b/tests/examples/pw/FeO_LDAU_standard.xml
@@ -99,10 +99,10 @@
         <Hubbard_U specie="O1" label="no Hubbard">
        0.0000000E+00
         </Hubbard_U>
-        <Hubbard_U specie="Fe1" label="no Hubbard">
+        <Hubbard_U specie="Fe1" label="3d">
        0.3160442E+00
         </Hubbard_U>
-        <Hubbard_U specie="Fe2" label="no Hubbard">
+        <Hubbard_U specie="Fe2" label="3d">
        0.3160442E+00
         </Hubbard_U>
         <Hubbard_J0 specie="O1" label="no Hubbard">

--- a/tests/examples/pw/FeO_LDAU_with_no_U.xml
+++ b/tests/examples/pw/FeO_LDAU_with_no_U.xml
@@ -99,10 +99,10 @@
         <Hubbard_U specie="O1" label="no Hubbard">
        0.0000000E+00
         </Hubbard_U>
-        <Hubbard_U specie="Fe1" label="no Hubbard">
+        <Hubbard_U specie="Fe1" label="3d">
        0.7349865E-09
         </Hubbard_U>
-        <Hubbard_U specie="Fe2" label="no Hubbard">
+        <Hubbard_U specie="Fe2" label="3d">
        0.7349865E-09
         </Hubbard_U>
         <Hubbard_J0 specie="O1" label="no Hubbard">

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -33,8 +33,8 @@ class TestConversionFunctions(unittest.TestCase):
                     {'@name': 'Fe2', 'mass': 1.0, 'pseudo_file': 'Fe.pz-nd-rrkjus.UPF',
                      'starting_magnetization': -0.5}]},
             'Hubbard_U': [{'@specie': 'O1', '@label': 'no Hubbard', '$': 0.0},
-                          {'@specie': 'Fe1', '@label': 'no Hubbard', '$': 0.3160442},
-                          {'@specie': 'Fe2', '@label': 'no Hubbard', '$': 0.3160442}],
+                          {'@specie': 'Fe1', '@label': '3d', '$': 0.3160442},
+                          {'@specie': 'Fe2', '@label': '3d', '$': 0.3160442}],
             '_related_tag': 'Hubbard_U'
         }
         result = get_specie_related_values('Hubbard_U', **kwargs)


### PR DESCRIPTION
... and  changing tests accordingly
 Changes to be committed:
	modified:   qeschema/options.py
	modified:   tests/examples/pw/FeO_LDAU_standard.xml
	modified:   tests/examples/pw/FeO_LDAU_with_no_U.xml
	modified:   tests/test_options.py