### PR TITLE
adding exception management

### DIFF
--- a/qeschema/converters.py
+++ b/qeschema/converters.py
@@ -538,8 +538,12 @@ class PwInputConverter(RawInputConverter):
             input_cards=('ATOMIC_SPECIES', 'ATOMIC_POSITIONS', 'K_POINTS',
                          'CELL_PARAMETERS', 'ATOMIC_FORCES')
         )
-        if 'xml_file' in kwargs:
-            self._input['CONTROL']['input_xml_schema_file'] = u'\'{}\''.format(os.path.basename(kwargs['xml_file']))
+        try:
+            if 'xml_file' in kwargs:
+                self._input['CONTROL']['input_xml_schema_file'] = u'\'{}\''.format(os.path.basename(kwargs['xml_file']))
+        except TypeError as TE:
+            if kwargs['xml_file'] is not None:
+                raise 
 
     def clear_input(self):
         super(PwInputConverter, self).clear_input()


### PR DESCRIPTION

For documents built runtime the filename variable with a path to the xml file should  stay  uninitialized with a None value. But this causes the function to raise a TypeError exception when trying to extract the path from filename for inserting it in the `control` namelist.  With this pull request the exception is ignored when the type of the filename value is None.   


 