### PR TITLE
WIP:add self detection of schema format

### DIFF
--- a/qeschema/documents.py
+++ b/qeschema/documents.py
@@ -538,7 +538,16 @@ class PwDocument(QeDocument):
     """
     def __init__(self, source=None, schema=None):
         if schema is None:
-            schema = os.path.join(self.SCHEMAS_DIR, 'qes.xsd')
+            try:
+                parse = ElementTree.parse(source)
+                root = parse.getroot()
+                key = '{http://www.w3.org/2001/XMLSchema-instance}' \
+                      'schemaLocation'
+                schema_name = root.attrib[key].split()[1].split('/')[-1]
+                schema = os.path.join(self.SCHEMAS_DIR, 'releases',  schema_name)
+            except TypeError:
+                logger.warning('loading default schema')
+                schema = os.path.join(self.SCHEMAS_DIR, 'qes.xsd')
         super(PwDocument, self).__init__(source, schema, input_builder=PwInputConverter)
 
     @requires_xml_data


### PR DESCRIPTION
I don't know if this was an intended behaviour but I would prefer if the schema is self detected by the code rather than being a separate parameter. 

The idea of this pull request is simply to implement this behaviour for the pw xml with a fall-back to the old behaviour.

Another proposed change is to use the pkgutil package to recover the schema path like:
pkgutil.get_data('qeschema', 'schemas/qes.xsd')

A separate thing that I don't understand is: why allow to initializate ad object with no source? 
