### PR TITLE
Fix schema fetching

### DIFF
--- a/qeschema/documents.py
+++ b/qeschema/documents.py
@@ -85,7 +85,7 @@ class XmlDocument(object):
                 source = xmlschema.XMLResource(source)
 
             if source.namespace == XSD_NAMESPACE:
-                XmlDocumentError("source is an XSD schema")
+                raise XmlDocumentError("source is an XSD schema")
 
             for ns, location in source.iter_location_hints():
                 if ns == source.namespace:
@@ -102,7 +102,8 @@ class XmlDocument(object):
         elif source_schema is not None:
             self.schema = xmlschema.XMLSchema(source_schema)
         elif self.DEFAULT_SCHEMA is not None:
-            self.schema = xmlschema.XMLSchema(self.DEFAULT_SCHEMA)
+            default_schema = self.fetch_schema(self.DEFAULT_SCHEMA)
+            self.schema = xmlschema.XMLSchema(default_schema)
         else:
             raise XmlDocumentError("missing schema for XML data!")
 

--- a/qeschema/documents.py
+++ b/qeschema/documents.py
@@ -97,6 +97,9 @@ class XmlDocument(object):
 
         if isinstance(schema, xmlschema.XMLSchemaBase):
             self.schema = schema
+        elif isinstance(schema, str) and '\n' not in schema \
+                and not schema.lstrip().startswith('<'):
+            self.schema = xmlschema.XMLSchema(self.fetch_schema(schema) or schema)
         elif schema is not None:
             self.schema = xmlschema.XMLSchema(schema)
         elif source_schema is not None:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 setuptools
 tox
 coverage
-xmlschema~=1.0.15
+xmlschema>=1.3.0
 pyyaml
 Sphinx
 sphinx_rtd_theme

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open("README.rst") as readme:
 setup(
     name='qeschema',
     version='1.0.0',
-    install_requires=['xmlschema~=1.0.15', 'pyyaml'],
+    install_requires=['xmlschema>=1.3.0', 'pyyaml'],
     packages=['qeschema'],
     package_data={'qeschema': ['schemas/*.xsd']},
     scripts = ['scripts/xml2qeinput.py', 'scripts/yaml2qeinput.py'],

--- a/tests/examples/dummy/instance_json
+++ b/tests/examples/dummy/instance_json
@@ -1,1 +1,1 @@
-{"root": {"node": [null, null, null]}}
+{"root": {"node": [null, {"$": "value"}, null]}}

--- a/tests/examples/dummy/instance_yaml
+++ b/tests/examples/dummy/instance_yaml
@@ -1,5 +1,5 @@
 root:
   node:
   - null
-  - null
+  - $: value
   - null

--- a/tests/examples/pw/Al001_relax_bfgs.xml
+++ b/tests/examples/pw/Al001_relax_bfgs.xml
@@ -1,6 +1,6 @@
 <qes:espresso xmlns:qes="http://www.quantum-espresso.org/ns/qes/qes-1.0"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-              xsi:schemaLocation="http://www.quantum-espresso.org/ns/qes/qes-1.0 ../../../qeschema/schemas/qes.xsd">
+              xsi:schemaLocation="http://www.quantum-espresso.org/ns/qes/qes-1.0 releases/qes_190719.xsd">
     <input>
     <control_variables>
       <title>

--- a/tests/examples/pw/Al001_relax_bfgs.yml
+++ b/tests/examples/pw/Al001_relax_bfgs.yml
@@ -1,6 +1,6 @@
 '{http://www.quantum-espresso.org/ns/qes/qes-1.0}espresso':
   '@{http://www.w3.org/2001/XMLSchema-instance}schemaLocation': http://www.quantum-espresso.org/ns/qes/qes-1.0
-    ../../../qeschema/schemas/qes.xsd
+    releases/qes_190719.xsd
   input:
     atomic_species:
       '@ntyp': 1

--- a/tests/examples/pw/Al001_rlx_damp.xml
+++ b/tests/examples/pw/Al001_rlx_damp.xml
@@ -1,6 +1,6 @@
 <qes:espresso xmlns:qes="http://www.quantum-espresso.org/ns/qes/qes-1.0"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-              xsi:schemaLocation="http://www.quantum-espresso.org/ns/qes/qes-1.0 ../../../qeschema/schemas/qes.xsd">
+              xsi:schemaLocation="http://www.quantum-espresso.org/ns/qes/qes-1.0 unknown/qes.xsd">
   <input>
     <control_variables>
       <title> Al001 relaxation with damped dynamics </title>

--- a/tests/examples/pw/Al_bands.xml
+++ b/tests/examples/pw/Al_bands.xml
@@ -1,6 +1,6 @@
 <qes:espresso xmlns:qes="http://www.quantum-espresso.org/ns/qes/qes-1.0"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-              xsi:schemaLocation="http://www.quantum-espresso.org/ns/qes/qes-1.0 ../../../qeschema/schemas/qes.xsd">
+              xsi:schemaLocation="http://www.quantum-espresso.org/ns/qes/qes-1.0 /unknown_path/qes_190304.xsd">
   <input>
     <control_variables>
       <title>

--- a/tests/examples/pw/CO_bgfs_relax.xml
+++ b/tests/examples/pw/CO_bgfs_relax.xml
@@ -1,6 +1,6 @@
 <qes:espresso xmlns:qes="http://www.quantum-espresso.org/ns/qes/qes-1.0"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-              xsi:schemaLocation="http://www.quantum-espresso.org/ns/qes/qes-1.0 ../../../qeschema/schemas/qes.xsd">
+              xsi:schemaLocation="http://www.quantum-espresso.org/ns/qes/qes-1.0 missing.xsd">
   <input>
     <control_variables>
       <title>CO bfgs relaxation</title>

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -366,7 +366,12 @@ class TestDocuments(unittest.TestCase):
         document = TdDocument(source=xml_filename)
 
         self.assertTrue(hasattr(document.root, 'tag'))
-        self.assertEqual(document.root.tag, '{http://www.quantum-espresso.org/ns/qes/qes_lr-1.0}tddfpt')
+        self.assertEqual(document.root.tag,
+                         '{http://www.quantum-espresso.org/ns/qes/qes_lr-1.0}tddfpt')
+
+        print(document.filename)
+
+
         self.assertEqual(document.filename, xml_filename)
         self.assertEqual(document.format, 'xml')
         self.assertEqual(document.input_path, 'input')
@@ -378,7 +383,8 @@ class TestDocuments(unittest.TestCase):
 
         document.read(xml_filename)
         self.assertTrue(hasattr(document.root, 'tag'))
-        self.assertEqual(document.root.tag, '{http://www.quantum-espresso.org/ns/qes/qes_spectrum-1.0}spectrumDoc')
+        self.assertEqual(document.root.tag,
+                         '{http://www.quantum-espresso.org/ns/qes/qes_spectrum-1.0}spectrumDoc')
         self.assertEqual(document.filename, xml_filename)
         self.assertEqual(document.format, 'xml')
         self.assertEqual(document.input_path, 'spectrumIn')

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -12,8 +12,8 @@ import unittest
 import xml.etree.ElementTree as ElementTree
 from xmlschema import XMLSchemaValidationError, XMLSchema
 
-from qeschema import PwDocument, PhononDocument, NebDocument, TdDocument, \
-    TdSpectrumDocument, XmlDocumentError
+from qeschema import QeDocument, PwDocument, PhononDocument, NebDocument, \
+    TdDocument, TdSpectrumDocument, XmlDocumentError
 from qeschema.documents import XmlDocument
 
 
@@ -44,24 +44,92 @@ class TestDocuments(unittest.TestCase):
         self.assertTrue(document.schema.url.endswith(schema))
         self.assertIsInstance(document.schema, XMLSchema)
 
+    def test_pw_document_init(self):
+        document = PwDocument()
         self.assertIsInstance(PwDocument(), PwDocument)
-        self.assertIsInstance(PwDocument(schema=schema), PwDocument)
+        self.assertTrue(document.schema.url.endswith("qeschema/qeschema/schemas/qes.xsd"))
 
+        schema = os.path.join(self.schemas_dir, 'qes.xsd')
+        document = PwDocument(schema=schema)
+        self.assertIsInstance(document, PwDocument)
+        self.assertTrue(document.schema.url.endswith("qeschema/qeschema/schemas/qes.xsd"))
+
+        document = PwDocument(schema='qes.xsd')
+        self.assertIsInstance(document, PwDocument)
+        self.assertTrue(document.schema.url.endswith("qeschema/qeschema/schemas/qes.xsd"))
+
+        document = PwDocument(schema='qes-20180511.xsd')
+        self.assertIsInstance(document, PwDocument)
+        self.assertTrue(document.schema.url.endswith("qeschema/schemas/releases/qes-20180511.xsd"))
+
+        source = os.path.join(self.test_dir, 'examples/pw/Al001_relax_bfgs.xml')
+        document = PwDocument(source)
+        self.assertEqual(document.filename, source)
+        self.assertTrue(document.schema.url.endswith("qeschema/schemas/releases/qes_190719.xsd"))
+
+        document = PwDocument(source, schema='qes.xsd')
+        self.assertEqual(document.filename, source)
+        self.assertTrue(document.schema.url.endswith("qeschema/schemas/qes.xsd"))
+
+        source = os.path.join(self.test_dir, 'examples/pw/Al001_rlx_damp.xml')
+        document = PwDocument(source)
+        self.assertEqual(document.filename, source)
+        self.assertTrue(document.schema.url.endswith("qeschema/schemas/qes.xsd"))
+
+        source = os.path.join(self.test_dir, 'examples/pw/CO_bgfs_relax.xml')
+        document = PwDocument(source)
+        self.assertEqual(document.filename, source)
+        self.assertTrue(document.schema.url.endswith("qeschema/schemas/qes.xsd"))
+
+    def test_phonon_document_init(self):
         schema = os.path.join(self.schemas_dir, 'ph_temp.xsd')
         self.assertIsInstance(PhononDocument(), PhononDocument)
+        self.assertTrue(PhononDocument().schema.url.endswith("qeschema/schemas/ph_temp.xsd"))
         self.assertIsInstance(PhononDocument(schema=schema), PhononDocument)
 
+    def test_neb_document_init(self):
         schema = os.path.join(self.schemas_dir, 'qes_neb.xsd')
         self.assertIsInstance(NebDocument(), NebDocument)
+        self.assertTrue(NebDocument().schema.url.endswith("qeschema/schemas/qes_neb.xsd"))
         self.assertIsInstance(NebDocument(schema=schema), NebDocument)
 
+    def test_td_document_init(self):
         schema = os.path.join(self.schemas_dir, 'tddfpt.xsd')
         self.assertIsInstance(TdDocument(), TdDocument)
+        self.assertTrue(TdDocument().schema.url.endswith("qeschema/qeschema/schemas/tddfpt.xsd"))
         self.assertIsInstance(TdDocument(schema=schema), TdDocument)
 
+    def test_td_spectrum_document_init(self):
         schema = os.path.join(self.schemas_dir, 'qes_spectrum.xsd')
         self.assertIsInstance(TdSpectrumDocument(), TdSpectrumDocument)
+        self.assertTrue(TdSpectrumDocument().schema.url.endswith("schemas/qes_spectrum.xsd"))
         self.assertIsInstance(TdSpectrumDocument(schema=schema), TdSpectrumDocument)
+
+    def test_fetch_schema(self):
+        self.assertIsNone(XmlDocument.fetch_schema('missing.xsd'))
+        self.assertIsNone(XmlDocument.fetch_schema('qes.xsd'))
+        self.assertIsNone(QeDocument.fetch_schema('missing.xsd'))
+
+        filename = QeDocument.fetch_schema('qes.xsd')
+        self.assertTrue(filename.endswith("qeschema/schemas/qes.xsd"))
+
+        filename = QeDocument.fetch_schema('unknown-path/qes.xsd')
+        self.assertTrue(filename.endswith("qeschema/schemas/qes.xsd"))
+
+        filename = QeDocument.fetch_schema('/unknown-path/qes.xsd')
+        self.assertTrue(filename.endswith("qeschema/schemas/qes.xsd"))
+
+        filename = QeDocument.fetch_schema('file:///unknown-path/qes.xsd')
+        self.assertTrue(filename.endswith("qeschema/schemas/qes.xsd"))
+
+        filename = QeDocument.fetch_schema('releases/qes.xsd')
+        self.assertTrue(filename.endswith("qeschema/schemas/qes.xsd"))
+
+        filename = QeDocument.fetch_schema('qes_190304.xsd')
+        self.assertTrue(filename.endswith("qeschema/schemas/releases/qes_190304.xsd"))
+
+        filename = QeDocument.fetch_schema('unknown/qes_190304.xsd')
+        self.assertTrue(filename.endswith("qeschema/schemas/releases/qes_190304.xsd"))
 
     def test_schema_namespaces(self):
         schema = os.path.join(self.schemas_dir, 'qes.xsd')


### PR DESCRIPTION
Refactoring of XmlDocument initialization for using the class default schema as last instance
  - Add DEFAULT_SCHEMA and DEFAULT_INPUT_BUILDER to derived classes for handling default schema and input builder
  - Add tests for _fetch_schema()_
  - Update dependency to xmlschema>=1.3.0 (more features and more reliable)

With class default schema is no more necessary to use schema argument to provide a default. 
With only the argument _source_ the schema is fetched from location hints, otherwise the default is used.
If an explicit argument _schema_ is provided the XML file location hints are ignored. 