### PR TITLE
Make h5py optional dependency

### DIFF
--- a/qeschema/hdf5/charge.py
+++ b/qeschema/hdf5/charge.py
@@ -6,7 +6,12 @@
 # http://opensource.org/licenses/MIT.
 #
 import numpy as np
-import h5py
+
+try:
+    import h5py
+except ImportError:
+    h5py = None
+    H5PY_ERR = 'h5py module is missing'
 
 
 def read_charge_file_hdf5(filename):
@@ -17,6 +22,10 @@ def read_charge_file_hdf5(filename):
     :return: a dictionary describing the content of file \
     keys=[nr, ngm_g, gamma_only, rhog_, MillerIndexes]
     """
+
+    if not h5py:
+        raise ImportError(H5PY_ERR)
+
     with h5py.File(filename, "r") as h5f:
         MI = h5f.get('MillerIndices')[:]
         nr1 = 2 * max(abs(MI[:, 0])) + 1

--- a/qeschema/hdf5/readutils.py
+++ b/qeschema/hdf5/readutils.py
@@ -9,8 +9,13 @@
 A collection of functions for reading different files and quantities.
 """
 import numpy as np
-import h5py
 from xml.etree import ElementTree
+
+try:
+    import h5py
+except ImportError:
+    h5py = None
+    H5PY_ERR = 'h5py module is missing'
 
 
 # TODO update to the new format
@@ -21,6 +26,10 @@ def get_wf_attributes(filename):
     :param filename: the path to the wfc file
     :return: a dictionary with all attributes included reciprocal vectors
     """
+
+    if not h5py:
+        raise ImportError(H5PY_ERR)
+
     with h5py.File(filename, "r") as f:
         res = dict(f.attrs)
         mi_attrs = f.get('MillerIndices').attrs
@@ -40,6 +49,10 @@ def get_wavefunctions(filename, start_band=None, stop_band=None):
     :param stop_band:  last band to read, default last band in the file
     :return: a numpy array with shape [nbnd,npw]
     """
+
+    if not h5py:
+        raise ImportError(H5PY_ERR)
+
     with h5py.File(filename, "r") as f:
         igwx = f.attrs.get('igwx')
         if start_band is None:
@@ -61,6 +74,10 @@ def get_wfc_miller_indices(filename):
     :param filename: path to the wfc file
     :return: a np.array of integers with shape [igwx,3]
     """
+
+    if not h5py:
+        raise ImportError(H5PY_ERR)
+
     with h5py.File(filename, "r") as f:
         res = f.get("MillerIndices")[:, :]
     return res

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open("README.rst") as readme:
 setup(
     name='qeschema',
     version='1.2.0',
-    install_requires=['xmlschema>=1.3.0', 'pyyaml', 'numpy', 'h5py'],
+    install_requires=['xmlschema>=1.3.0', 'pyyaml', 'numpy'],
     packages=['qeschema'],
     package_data={'qeschema': ['schemas/*.xsd']},
     scripts = ['scripts/xml2qeinput.py', 'scripts/yaml2qeinput.py'],


### PR DESCRIPTION
Hi All,

I'm trying to move Schrodinger to use qeschema instead of qexsd. We don't distribute h5py and qexsd doesn't have this dependency. In general it seems an overkill that xml to .in converter requires hdf5 package.

This PR makes h5py optional.

Thanks,
Sasha