### PR TITLE
Expose cell_dofree 2Dxy needed by ESM

### DIFF
--- a/qeschema/converters.py
+++ b/qeschema/converters.py
@@ -477,6 +477,7 @@ class PwInputConverter(RawInputConverter):
             'free_cell': ("CELL_PARAMETERS", cards.get_cell_parameters_card, None),
             'fix_volume': ("CELL[cell_dofree]", options.get_cell_dofree, None),
             'fix_area': ("CELL[cell_dofree]", options.get_cell_dofree, None),
+            'fix_xy': ("CELL[cell_dofree]", options.get_cell_dofree, None),
             'isotropic': ("CELL[cell_dofree]", options.get_cell_dofree, None),
         },
         'symmetry_flags': {

--- a/qeschema/options.py
+++ b/qeschema/options.py
@@ -210,31 +210,21 @@ def get_control_gdir(name, **kwargs):
 
 def get_cell_dofree(name, **kwargs):
     assert isinstance(name, str)
-    try:
-        fix_volume = kwargs['fix_volume']
-    except KeyError:
-        fix_volume = False
-    try:
-        fix_area = kwargs['fix_area']
-    except KeyError:
-        fix_area = False
-    try:
-        isotropic = kwargs['isotropic']
-    except KeyError:
-        isotropic = False
+    cell_dofree_str = "cell_dofree = '%s'"
+    cell_dofree_all = 'all'
 
-    cell_dofree = "cell_dofree = 'all'"
-    if (fix_volume and fix_area) or (fix_volume and isotropic) or (fix_area and isotropic):
-        logger.error("only one of fix_volume fix_area and isotropic can be true")
-        return [cell_dofree]
+    map_data = {
+        'fix_volume': 'shape',
+        'fix_area': '2Dshape',
+        'fix_xy': '2Dxy',
+        'isotropic': 'volume'
+    }
 
-    if fix_volume:
-        cell_dofree = "cell_dofree = 'shape'"
-    if fix_area:
-        cell_dofree = "cell_dofree = '2Dshape'"
-    if isotropic:
-        cell_dofree = "cell_dofree = 'volume'"
-    return [cell_dofree]
+    for key, val in map_data.items():
+        if kwargs.get(key):
+            return [cell_dofree_str % val]
+
+    return [cell_dofree_str % cell_dofree_all]
 
 
 def neb_set_system_nat(name, **kwargs):

--- a/qeschema/schemas/qes.xsd
+++ b/qeschema/schemas/qes.xsd
@@ -589,9 +589,12 @@ Authors: Antonio Zambon, Paolo Giannozzi, Pietro Delugas
       <element type="double" name="pressure" default="0.0" />
       <element type="double" name="wmass" minOccurs="0" />
       <element type="double" name="cell_factor" minOccurs="0" />
-      <element type="boolean" name="fix_volume" minOccurs="0" />
-      <element type="boolean" name="fix_area"   minOccurs="0" />
-      <element type="boolean" name="isotropic" minOccurs="0" />
+      <choice minOccurs="0" maxOccurs="1">
+        <element type="boolean" name="fix_volume" />
+        <element type="boolean" name="fix_area" />
+        <element type="boolean" name="fix_xy" />
+        <element type="boolean" name="isotropic" />
+      </choice>
       <element type="qes:integerMatrixType" name="free_cell" minOccurs="0" />
     </sequence>
   </complexType>

--- a/tests/examples/pw/ESM_2Dxy.in.test
+++ b/tests/examples/pw/ESM_2Dxy.in.test
@@ -1,0 +1,116 @@
+&CONTROL
+ calculation='relax'
+ disk_io='low'
+ dt=41.3414
+ etot_conv_thr=1e-05
+ forc_conv_thr=0.001
+ input_xml_schema_file='ESM_2Dxy.xml'
+ iprint=100000
+ max_seconds=10000000
+ nstep=2
+ outdir='./'
+ prefix='ESM_2Dxy'
+ pseudo_dir='./'
+ restart_mode='from_scratch'
+ title='ESM_2Dxy'
+ tprnfor=.false.
+ tstress=.false.
+ verbosity='low'
+ wf_collect=.false.
+/
+&SYSTEM
+ assume_isolated='esm'
+ degauss=0.01
+ ecutrho=200.0
+ ecutwfc=40.0
+ esm_bc='bc3'
+ esm_efield=0.0
+ esm_nfit=4
+ esm_w=0.0
+ force_symmorphic=.false.
+ ibrav=0
+ input_dft='PBE'
+ lspinorb=.false.
+ nat=25
+ nbnd=42
+ no_t_rev=.false.
+ noinv=.false.
+ noncolin=.false.
+ nosym=.true.
+ nosym_evc=.false.
+ nspin=1
+ ntyp=2
+ occupations='smearing'
+ smearing='gaussian'
+ spline_ps=.false.
+ starting_magnetization(1)=0.0
+ starting_magnetization(2)=0.0
+ tot_charge=-0.01
+ tot_magnetization=-1.0
+ use_all_frac=.false.
+/
+&ELECTRONS
+ conv_thr=1e-06
+ diago_cg_maxiter=20
+ diago_full_acc=.false.
+ diago_thr_init=0.0
+ diagonalization='davidson'
+ electron_maxstep=10
+ mixing_beta=0.7
+ mixing_mode='plain'
+ mixing_ndim=8
+ tbeta_smoothing=.false.
+ tq_smoothing=.false.
+ tqr=.false.
+/
+&IONS
+ delta_t=1.0
+ ion_dynamics='damp'
+ ion_temperature='rescale-v'
+ nraise=1
+ pot_extrapolation='atomic'
+ tempw=300.0
+ tolp=100.0
+ wfc_extrapolation='none'
+/
+&CELL
+cell_dofree = '2Dxy'
+ cell_dynamics='damp-pr'
+ cell_factor=2.0
+ press=0.0
+ press_conv_thr=0.5
+/
+ATOMIC_SPECIES
+ C 12.0107 c_pbe_v0.4.nc.UPF
+ H 1.00794 h_pbe_v0.4.nc.UPF
+ATOMIC_POSITIONS crystal
+C     -0.29463100    0.19161700   -0.12509200
+C     -0.14272000    0.19161700   -0.12509200
+C     -0.06676400    0.00000000   -0.12509200
+C     -0.14272000   -0.19161700   -0.12509200
+C     -0.29463100   -0.19161700   -0.12509200
+C     -0.37058700    0.00000000   -0.12509200
+C      0.09718900    0.00000000   -0.12509200
+C      0.15184000    0.00000000    0.01633000
+C      0.17715900    0.19161700    0.08184700
+C      0.22779600    0.19161700    0.21288100
+C      0.25311400    0.00000000    0.27839800
+C      0.22779600   -0.19161700    0.21288100
+C      0.17715900   -0.19161700    0.08184700
+H     -0.35376700    0.34080000   -0.12509200
+H     -0.08358500    0.34080000   -0.12509200
+H     -0.08358500   -0.34080000   -0.12509200
+H     -0.35376600   -0.34080000   -0.12509200
+H     -0.48885800    0.00000000   -0.12509200
+H      0.13690200   -0.14168500   -0.17647500
+H      0.13690200    0.14168500   -0.17647500
+H      0.15744700    0.34080000    0.03083800
+H      0.24750800    0.34080000    0.26388900
+H      0.29253800    0.00000000    0.38041500
+H      0.24750800   -0.34080000    0.26388900
+H      0.15744700   -0.34080000    0.03083800
+K_POINTS gamma
+CELL_PARAMETERS bohr
+ 17.28899500   0.00000000   0.00000000 
+  0.00000000  11.87016300   0.00000000 
+  0.00000000   0.00000000  18.89726100 

--- a/tests/examples/pw/ESM_2Dxy.xml
+++ b/tests/examples/pw/ESM_2Dxy.xml
@@ -1,0 +1,222 @@
+<qes:espresso xmlns:qes="http://www.quantum-espresso.org/ns/qes/qes-1.0"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="http://www.quantum-espresso.org/ns/qes/qes-1.0 ../qespresso/scheme/qes.xsd">
+<input>
+<control_variables>
+<title>ESM_2Dxy</title>
+<calculation>relax</calculation>
+<restart_mode>from_scratch</restart_mode>
+<prefix>ESM_2Dxy</prefix>
+<pseudo_dir>./</pseudo_dir>
+<outdir>./</outdir>
+<stress>false</stress>
+<forces>false</forces>
+<wf_collect>false</wf_collect>
+<disk_io>low</disk_io>
+<max_seconds>10000000</max_seconds>
+<nstep>2</nstep>
+<etot_conv_thr>1.00000e-05</etot_conv_thr>
+<forc_conv_thr>1.00000e-03</forc_conv_thr>
+<press_conv_thr>5.00000e-01</press_conv_thr>
+<verbosity>low</verbosity>
+<print_every>100000</print_every>
+</control_variables>
+<atomic_species ntyp="2">
+<species name="C">
+<mass>12.010700</mass>
+<pseudo_file>c_pbe_v0.4.nc.UPF</pseudo_file>
+<starting_magnetization>0.000000</starting_magnetization>
+</species>
+<species name="H">
+<mass>1.007940</mass>
+<pseudo_file>h_pbe_v0.4.nc.UPF</pseudo_file>
+<starting_magnetization>0.000000</starting_magnetization>
+</species>
+</atomic_species>
+<atomic_structure nat="25" alat="1.0">
+<crystal_positions>
+<atom name="C" index="1">
+-0.294631 0.191617 -0.125092
+</atom>
+<atom name="C" index="2">
+-0.142720 0.191617 -0.125092
+</atom>
+<atom name="C" index="3">
+-0.066764 0.000000 -0.125092
+</atom>
+<atom name="C" index="4">
+-0.142720 -0.191617 -0.125092
+</atom>
+<atom name="C" index="5">
+-0.294631 -0.191617 -0.125092
+</atom>
+<atom name="C" index="6">
+-0.370587 0.000000 -0.125092
+</atom>
+<atom name="C" index="7">
+0.097189 0.000000 -0.125092
+</atom>
+<atom name="C" index="8">
+0.151840 0.000000 0.016330
+</atom>
+<atom name="C" index="9">
+0.177159 0.191617 0.081847
+</atom>
+<atom name="C" index="10">
+0.227796 0.191617 0.212881
+</atom>
+<atom name="C" index="11">
+0.253114 0.000000 0.278398
+</atom>
+<atom name="C" index="12">
+0.227796 -0.191617 0.212881
+</atom>
+<atom name="C" index="13">
+0.177159 -0.191617 0.081847
+</atom>
+<atom name="H" index="14">
+-0.353767 0.340800 -0.125092
+</atom>
+<atom name="H" index="15">
+-0.083585 0.340800 -0.125092
+</atom>
+<atom name="H" index="16">
+-0.083585 -0.340800 -0.125092
+</atom>
+<atom name="H" index="17">
+-0.353766 -0.340800 -0.125092
+</atom>
+<atom name="H" index="18">
+-0.488858 0.000000 -0.125092
+</atom>
+<atom name="H" index="19">
+0.136902 -0.141685 -0.176475
+</atom>
+<atom name="H" index="20">
+0.136902 0.141685 -0.176475
+</atom>
+<atom name="H" index="21">
+0.157447 0.340800 0.030838
+</atom>
+<atom name="H" index="22">
+0.247508 0.340800 0.263889
+</atom>
+<atom name="H" index="23">
+0.292538 0.000000 0.380415
+</atom>
+<atom name="H" index="24">
+0.247508 -0.340800 0.263889
+</atom>
+<atom name="H" index="25">
+0.157447 -0.340800 0.030838
+</atom>
+</crystal_positions>
+<cell>
+<a1>17.288995 0.000000 0.000000</a1>
+<a2>0.000000 11.870163 0.000000</a2>
+<a3>0.000000 0.000000 18.897261</a3>
+</cell>
+</atomic_structure>
+<dft>
+<functional>PBE</functional>
+</dft>
+<spin>
+<lsda>false</lsda>
+<noncolin>false</noncolin>
+<spinorbit>false</spinorbit>
+</spin>
+<bands>
+<nbnd>42</nbnd>
+<smearing degauss="0.010000">gaussian</smearing>
+<tot_charge>-0.010000</tot_charge>
+<tot_magnetization>-1.000000</tot_magnetization>
+<occupations>smearing</occupations>
+</bands>
+<basis>
+<gamma_only>true</gamma_only>
+<ecutwfc>40.000000</ecutwfc>
+<ecutrho>200.000000</ecutrho>
+<spline_ps>false</spline_ps>
+</basis>
+<electron_control>
+<diagonalization>davidson</diagonalization>
+<mixing_mode>plain</mixing_mode>
+<mixing_beta>0.700000</mixing_beta>
+<conv_thr>1.00000e-06</conv_thr>
+<mixing_ndim>8</mixing_ndim>
+<max_nstep>10</max_nstep>
+<real_space_q>false</real_space_q>
+<tq_smoothing>false</tq_smoothing>
+<tbeta_smoothing>false</tbeta_smoothing>
+<diago_thr_init>0.000000</diago_thr_init>
+<diago_full_acc>false</diago_full_acc>
+<diago_cg_maxiter>20</diago_cg_maxiter>
+</electron_control>
+<k_points_IBZ>
+<monkhorst_pack nk1="1" nk2="1" nk3="1" k1="0" k2="0" k3="0">K-point mesh</monkhorst_pack>
+</k_points_IBZ>
+<ion_control>
+<ion_dynamics>damp</ion_dynamics>
+<md>
+<pot_extrapolation>atomic</pot_extrapolation>
+<wfc_extrapolation>none</wfc_extrapolation>
+<ion_temperature>rescale-v</ion_temperature>
+<timestep>4.13414e+01</timestep>
+<tempw>3.00000e+02</tempw>
+<tolp>100.</tolp>
+<deltaT>1.00000e+00</deltaT>
+<nraise>1</nraise>
+</md>
+</ion_control>
+<cell_control>
+<cell_dynamics>damp-pr</cell_dynamics>
+<pressure>0.000000</pressure>
+<cell_factor>2.000000</cell_factor>
+<fix_xy>true</fix_xy>
+</cell_control>
+<symmetry_flags>
+<nosym>true</nosym>
+<nosym_evc>false</nosym_evc>
+<noinv>false</noinv>
+<no_t_rev>false</no_t_rev>
+<force_symmorphic>false</force_symmorphic>
+<use_all_frac>false</use_all_frac>
+</symmetry_flags>
+<boundary_conditions>
+<assume_isolated>esm</assume_isolated>
+<esm>
+<bc>bc3</bc>
+<nfit>4</nfit>
+<w>0.0</w>
+<efield>0.0</efield>
+</esm>
+</boundary_conditions>
+<free_positions rank="2" dims="3 25" order="F">
+1 1 1
+1 1 1
+1 1 1
+1 1 1
+1 1 1
+1 1 1
+1 1 1
+1 1 1
+1 1 1
+1 1 1
+1 1 1
+1 1 1
+1 1 1
+1 1 1
+1 1 1
+1 1 1
+1 1 1
+1 1 1
+1 1 1
+1 1 1
+1 1 1
+1 1 1
+1 1 1
+1 1 1
+1 1 1
+</free_positions>
+</input>
+</qes:espresso>


### PR DESCRIPTION
This resolves https://github.com/QEF/qeschema/issues/21.

ESM requires cell_dofree = '2Dxy'. In the qesxd it was labeled fix_xy. This PR is to add fix_xy the the schema.