### PR TITLE
Fix nat_todo in the PH schema

### DIFF
--- a/qeschema/cards.py
+++ b/qeschema/cards.py
@@ -292,6 +292,12 @@ def get_qpoints_card(name, **kwargs):
     return lines
 
 
+def get_nat_todo_card(name, **kwargs):
+    assert kwargs['nat_todo']['@natom'] == len(kwargs['nat_todo']['atom'])
+
+    return [' '.join(map(str, kwargs['nat_todo']['atom']))]
+
+
 def get_climbing_images(name, **kwargs):
     assert isinstance(name, str)
     try:

--- a/qeschema/cards.py
+++ b/qeschema/cards.py
@@ -293,9 +293,16 @@ def get_qpoints_card(name, **kwargs):
 
 
 def get_nat_todo_card(name, **kwargs):
-    assert kwargs['nat_todo']['@natom'] == len(kwargs['nat_todo']['atom'])
 
-    return [' '.join(map(str, kwargs['nat_todo']['atom']))]
+    natom = kwargs['nat_todo']['@natom']
+    if natom == 0:
+        assert 'atom' not in kwargs['nat_todo']
+        return []
+
+    atoms = kwargs['nat_todo']['atom']
+
+    assert natom == len(atoms)
+    return [' '.join(map(str, atoms))]
 
 
 def get_climbing_images(name, **kwargs):

--- a/qeschema/converters.py
+++ b/qeschema/converters.py
@@ -22,6 +22,8 @@ from . import cards, options
 logger = logging.getLogger('qeschema')
 
 FCP_NAMELIST = 'FCP'
+PH_NAT_TODO_CARD = 'ph_nat_todo_card'
+OPTIONAL_CARDS = {PH_NAT_TODO_CARD}
 
 
 def conversion_maps_builder(template_map):
@@ -274,14 +276,18 @@ class RawInputConverter(Container):
             logger.debug("Add card: %s" % card)
             card_args = _input[card]
             logger.debug("Card arguments: {0}".format(card_args))
-            if '_get_qe_input' not in card_args or \
-                    not callable(card_args['_get_qe_input']):
+
+            if (card not in OPTIONAL_CARDS and ('_get_qe_input' not in card_args
+                    or not callable(card_args['_get_qe_input']))):
                 logger.error("Missing conversion function for card '%s'" % card)
+
             _get_qe_input = card_args.get('_get_qe_input', None)
+
             if callable(_get_qe_input):
                 lines.extend(_get_qe_input(card, **card_args))
-            else:
+            elif card not in OPTIONAL_CARDS:
                 logger.error('Card conversion function not found!')
+
         return '\n'.join(lines)
 
     def clear_input(self):
@@ -627,7 +633,11 @@ class PhononInputConverter(RawInputConverter):
             'last_q': "INPUTPH[last_q]",
             'start_irr': "INPUTPH[start_irr]",
             'last_irr': "INPUTPH[last_irr]",
-            'nat_todo': "INPUTPH[nat_todo]",
+            'nat_todo':
+            {
+                '@natom': 'INPUTPH[nat_todo]',
+                '$': [(PH_NAT_TODO_CARD, cards.get_nat_todo_card, None)]
+            },
             'modenum': "INPUTPH[modenum]",
             'only_init': "INPUTPH[only_init]",
             'ldiag': "INPUTPH[ldiag]",
@@ -669,7 +679,7 @@ class PhononInputConverter(RawInputConverter):
         super(PhononInputConverter, self).__init__(
             *conversion_maps_builder(self.PHONON_TEMPLATE_MAP),
             input_namelists=('INPUTPH',),
-            input_cards=('qPointsSpecs',)
+            input_cards=('qPointsSpecs', PH_NAT_TODO_CARD)
         )
 
 

--- a/qeschema/schemas/ph_xmlschema.xsd
+++ b/qeschema/schemas/ph_xmlschema.xsd
@@ -300,9 +300,9 @@ Created by Mauro Palumbo
     <!-- nat_todo -->
     <complexType name="nat_todoType">
         <sequence>
-            <element type="positiveInteger" name="atom" minOccurs="1" maxOccurs="unbounded"/>
+            <element type="positiveInteger" name="atom" minOccurs="0" maxOccurs="unbounded"/>
         </sequence>
-        <attribute type="positiveInteger" name="natom"/>
+        <attribute type="nonNegativeInteger" name="natom"/>
     </complexType>
     <!-- end nat_todo -->
 <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->  

--- a/qeschema/schemas/ph_xmlschema.xsd
+++ b/qeschema/schemas/ph_xmlschema.xsd
@@ -296,7 +296,6 @@ Created by Mauro Palumbo
             </extension>
         </simpleContent>
     </complexType>
-
     <!-- nat_todo -->
     <complexType name="nat_todoType">
         <sequence>

--- a/qeschema/schemas/ph_xmlschema.xsd
+++ b/qeschema/schemas/ph_xmlschema.xsd
@@ -300,9 +300,9 @@ Created by Mauro Palumbo
     <!-- nat_todo -->
     <complexType name="nat_todoType">
         <sequence>
-            <element type="nonNegativeInteger" name="atom" minOccurs="1" maxOccurs="unbounded"/>
+            <element type="positiveInteger" name="atom" minOccurs="1" maxOccurs="unbounded"/>
         </sequence>
-        <attribute type="nonNegativeInteger" name="natom"/>
+        <attribute type="positiveInteger" name="natom"/>
     </complexType>
     <!-- end nat_todo -->
 <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->  

--- a/qeschema/schemas/ph_xmlschema.xsd
+++ b/qeschema/schemas/ph_xmlschema.xsd
@@ -204,9 +204,8 @@ Created by Mauro Palumbo
             <element type="positiveInteger" name="start_irr" default="1" 
                  minOccurs="0" />     
             <element type="positiveInteger" name="last_irr" default="3"
-                 minOccurs="0" />           
-            <element type="nonNegativeInteger" name="nat_todo" default="0"
-                 minOccurs="0" /> 
+                 minOccurs="0" />
+            <element type="qes_ph:nat_todoType" name="nat_todo" minOccurs="0" maxOccurs="1"/>
             <element type="nonNegativeInteger" name="modenum" default="0" 
                  minOccurs="0" />
             <element type="boolean" name="only_init" default="false" 
@@ -297,6 +296,15 @@ Created by Mauro Palumbo
             </extension>
         </simpleContent>
     </complexType>
+
+    <!-- nat_todo -->
+    <complexType name="nat_todoType">
+        <sequence>
+            <element type="nonNegativeInteger" name="atom" minOccurs="1" maxOccurs="unbounded"/>
+        </sequence>
+        <attribute type="nonNegativeInteger" name="natom"/>
+    </complexType>
+    <!-- end nat_todo -->
 <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->  
   <!-- k points, same as in qes schema -->
     <complexType name="k_points_IBZType">

--- a/tests/examples/ph/nat_todo.in.test
+++ b/tests/examples/ph/nat_todo.in.test
@@ -1,0 +1,16 @@
+&INPUTPH
+ epsil=.true.
+ fildyn='nat_todo.dyn'
+ ldisp=.true.
+ lraman=.false.
+ nat_todo=3
+ nq1=2
+ nq2=2
+ nq3=2
+ prefix='nat_todo'
+ tr2_ph=1e-14
+ trans=.true.
+ zeu=.false.
+ zue=.false.
+/
+1 3 5

--- a/tests/examples/ph/nat_todo.xml
+++ b/tests/examples/ph/nat_todo.xml
@@ -1,0 +1,31 @@
+<qes_ph:espressoph xmlns:qes_ph="http://www.quantum-espresso.org/ns/qes/qes_ph_1.0"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="http://www.quantum-espresso.org/ns/qes/qes_ph_1.0 ../../qespresso/scheme/ph_xmlschema.xsd">
+<inputPH>
+<files>
+<prefix>nat_todo</prefix>
+<fildyn>nat_todo.dyn</fildyn>
+</files>
+<scf_ph>
+<tr2_ph>1.0e-14</tr2_ph>
+</scf_ph>
+<control_ph>
+<ldisp>true</ldisp>
+<epsil>true</epsil>
+<trans>true</trans>
+<zeu>false</zeu>
+<zue>false</zue>
+<lraman>false</lraman>
+</control_ph>
+<irr_repr>
+<nat_todo natom="3">
+    <atom>1</atom>
+    <atom>3</atom>
+    <atom>5</atom>
+</nat_todo>
+</irr_repr>
+<q_points>
+<grid nq1="2" nq2="2" nq3="2"/>
+</q_points>
+</inputPH>
+</qes_ph:espressoph>

--- a/tests/examples/ph/nat_todo_zero.in.test
+++ b/tests/examples/ph/nat_todo_zero.in.test
@@ -1,0 +1,15 @@
+&INPUTPH
+ epsil=.false.
+ fildyn='nat_todo_zero.dyn'
+ ldisp=.true.
+ lraman=.false.
+ nat_todo=0
+ nq1=1
+ nq2=1
+ nq3=1
+ prefix='nat_todo_zero'
+ tr2_ph=1e-14
+ trans=.true.
+ zeu=.false.
+ zue=.false.
+/

--- a/tests/examples/ph/nat_todo_zero.xml
+++ b/tests/examples/ph/nat_todo_zero.xml
@@ -1,0 +1,28 @@
+<qes_ph:espressoph xmlns:qes_ph="http://www.quantum-espresso.org/ns/qes/qes_ph_1.0"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="http://www.quantum-espresso.org/ns/qes/qes_ph_1.0 ../../qespresso/scheme/ph_xmlschema.xsd">
+<inputPH>
+<files>
+<prefix>nat_todo_zero</prefix>
+<fildyn>nat_todo_zero.dyn</fildyn>
+</files>
+<scf_ph>
+<tr2_ph>1.0e-14</tr2_ph>
+</scf_ph>
+<control_ph>
+<ldisp>true</ldisp>
+<epsil>false</epsil>
+<trans>true</trans>
+<zeu>false</zeu>
+<zue>false</zue>
+<lraman>false</lraman>
+</control_ph>
+<irr_repr>
+<nat_todo natom="0">
+</nat_todo>
+</irr_repr>
+<q_points>
+<grid nq1="1" nq2="1" nq3="1"/>
+</q_points>
+</inputPH>
+</qes_ph:espressoph>


### PR DESCRIPTION
Besides nat_todo in the &INPUTPH, atom indices are required in the separate card.