### PR TITLE
Add HUBBARD card

### DIFF
--- a/qeschema/cards.py
+++ b/qeschema/cards.py
@@ -338,6 +338,7 @@ def get_hubbard_card(name, **kwargs):
 
     return lines
 
+
 #
 # Phonon Cards
 #

--- a/qeschema/converters.py
+++ b/qeschema/converters.py
@@ -362,29 +362,7 @@ class PwInputConverter(RawInputConverter):
                 'x_gamma_extrapolation': 'SYSTEM[x_gamma_extrapolation]',
                 'ecutvcut': ('SYSTEM[ecutvcut]', options.ha2ry, None)
             },
-            'dftU': {
-                'lda_plus_u_kind': 'SYSTEM[lda_plus_u_kind]',
-                'Hubbard_U': {
-                    '$': [('SYSTEM[Hubbard_U]', options.get_specie_related_values, None),
-                          ('SYSTEM[lda_plus_u]', options.set_lda_plus_u_flag, None)]
-                },
-                'Hubbard_J0': {
-                    '$': ('SYSTEM[Hubbard_J0]', options.get_specie_related_values, None),
-                },
-                'Hubbard_alpha': {
-                    '$': ('SYSTEM[Hubbard_alpha]', options.get_specie_related_values, None),
-                },
-                'Hubbard_beta': {
-                    '$': ('SYSTEM[Hubbard_beta]', options.get_specie_related_values, None),
-                },
-                'Hubbard_J': {
-                    '$': ('SYSTEM[Hubbard_J]', options.get_specie_related_values, None),
-                },
-                'starting_ns': {
-                    '$': ('SYSTEM[starting_ns_eigenvalue]', options.get_specie_related_values, None)
-                },
-                'U_projection_type': 'SYSTEM[U_projection_type]',
-            },
+            'dftU': ('HUBBARD', cards.get_hubbard_card, None),
             'vdW': {
                 'vdw_corr': 'SYSTEM[vdw_corr]',
                 'london_s6': 'SYSTEM[london_s6]',
@@ -561,7 +539,7 @@ class PwInputConverter(RawInputConverter):
             input_namelists=('CONTROL', 'SYSTEM', 'ELECTRONS', 'IONS', 'CELL',
                              FCP_NAMELIST),
             input_cards=('ATOMIC_SPECIES', 'ATOMIC_POSITIONS', 'K_POINTS',
-                         'CELL_PARAMETERS', 'ATOMIC_FORCES')
+                         'CELL_PARAMETERS', 'ATOMIC_FORCES', 'HUBBARD')
         )
         if 'xml_file' in kwargs:
             self._input['CONTROL']['input_xml_schema_file'] = "{!r}".format(
@@ -741,7 +719,7 @@ class NebInputConverter(RawInputConverter):
             *conversion_maps_builder(self.NEB_TEMPLATE_MAP),
             input_namelists=('PATH', 'CONTROL', 'SYSTEM', 'ELECTRONS', 'IONS', 'CELL'),
             input_cards=('CLIMBING_IMAGES', 'ATOMIC_SPECIES', 'ATOMIC_POSITIONS', 'K_POINTS',
-                         'CELL_PARAMETERS', 'ATOMIC_FORCES')
+                         'CELL_PARAMETERS', 'ATOMIC_FORCES', 'HUBBARD')
         )
 
     def get_qe_input(self):

--- a/tests/resources/pw/FeO_LDAU_standard.in.test
+++ b/tests/resources/pw/FeO_LDAU_standard.in.test
@@ -21,12 +21,8 @@
  ecutrho=240.0
  ecutwfc=30.0
  force_symmorphic=.false.
- Hubbard_U(2)=0.3160442
- Hubbard_U(3)=0.3160442
  ibrav=0
  input_dft='PZ'
- lda_plus_u = .true.
- lda_plus_u_kind=0
  lspinorb=.false.
  nat=4
  nbnd=20
@@ -43,7 +39,6 @@
  starting_magnetization(2)=0.5
  starting_magnetization(3)=-0.5
  tot_charge=0.0
- U_projection_type='atomic'
  use_all_frac=.false.
 /
 &ELECTRONS
@@ -87,3 +82,6 @@ CELL_PARAMETERS bohr
   0.50000000   0.50000000   1.00000000 
   0.50000000   1.00000000   0.50000000 
   1.00000000   0.50000000   0.50000000 
+HUBBARD atomic
+U Fe1-3d 0.3160442
+U Fe2-3d 0.3160442

--- a/tests/resources/pw/FeO_LDAU_with_no_U.in.test
+++ b/tests/resources/pw/FeO_LDAU_with_no_U.in.test
@@ -21,12 +21,8 @@
  ecutrho=240.0
  ecutwfc=30.0
  force_symmorphic=.false.
- Hubbard_U(2)=7.349865e-10
- Hubbard_U(3)=7.349865e-10
  ibrav=0
  input_dft='PZ'
- lda_plus_u = .true.
- lda_plus_u_kind=0
  lspinorb=.false.
  nat=4
  nbnd=20
@@ -43,7 +39,6 @@
  starting_magnetization(2)=0.5
  starting_magnetization(3)=-0.5
  tot_charge=0.0
- U_projection_type='atomic'
  use_all_frac=.false.
 /
 &ELECTRONS
@@ -87,3 +82,6 @@ CELL_PARAMETERS bohr
   0.50000000   0.50000000   1.00000000 
   0.50000000   1.00000000   0.50000000 
   1.00000000   0.50000000   0.50000000 
+HUBBARD atomic
+U Fe1-3d 7.349865e-10
+U Fe2-3d 7.349865e-10


### PR DESCRIPTION
I couldn't figure out how to add HUBBARD card (introduced in QE 7.1) and also print:

```
starting_ns_eigenvalue(3,1,3)=1.0
starting_ns_eigenvalue(3,2,2)=1.0
```

That's why FeO_LDAU_with_starting_ns.xml conversion is failing.