### PR TITLE
fix double reading of k points list by get_k_points of PwDocument (issue #40) 

### DIFF
--- a/qeschema/documents.py
+++ b/qeschema/documents.py
@@ -615,7 +615,7 @@ class PwDocument(QeDocument):
 
         :return: nested list with k_points
         """
-        path = './/output//k_point'
+        path = './/output//ks_energies/k_point'
         return [self.schema.find(path).decode(e)['$'] for e in self.findall(path)]
 
     @requires_xml_data


### PR DESCRIPTION
Fixes PwDocument class whose get_k_points method could, in some cases, also read the k_points list from another child of the `output` element.  Thanks, @fraricci, for reporting it. 